### PR TITLE
Fix ros2 build and add additional parameter for cog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,25 +28,36 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   tf2_ros
 )
 
-add_library(${PROJECT_NAME} SHARED
-  src/gravity_compensation.cpp
+add_library(low_pass_filter SHARED
   src/low_pass_filter.cpp
-  # src/threshold_filter.cpp
-  # src/kalman_filter.cpp
-  # src/moving_mean_filter.cpp
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(low_pass_filter PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
-target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
+ament_target_dependencies(low_pass_filter ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_compile_options(low_pass_filter PRIVATE -Wall -Wextra)
+
+
+add_library(gravity_compensation SHARED
+  src/gravity_compensation.cpp
+)
+
+target_include_directories(gravity_compensation PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(gravity_compensation ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_compile_options(gravity_compensation PRIVATE -Wall -Wextra)
+
+# TODO(sjahr) enable threshold_filter, kalman_filter, moving_mean_filter
 
 # Install Libraries
 install(
-  TARGETS ${PROJECT_NAME}
+  TARGETS low_pass_filter gravity_compensation
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -74,11 +85,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_gravity_compensation test/test_gravity_compensation.cpp)
   ament_target_dependencies(test_gravity_compensation ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  target_link_libraries(test_gravity_compensation ${PROJECT_NAME})
+  target_link_libraries(test_gravity_compensation gravity_compensation)
 
   ament_add_gtest(test_low_pass_filter test/test_low_pass_filter.cpp)
   ament_target_dependencies(test_low_pass_filter ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  target_link_libraries(test_low_pass_filter ${PROJECT_NAME})
+  target_link_libraries(test_low_pass_filter low_pass_filter)
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ target_include_directories(gravity_compensation PUBLIC
 ament_target_dependencies(gravity_compensation ${THIS_PACKAGE_INCLUDE_DEPENDS})
 target_compile_options(gravity_compensation PRIVATE -Wall -Wextra)
 
-# TODO(sjahr) enable threshold_filter, kalman_filter, moving_mean_filter
+# TODO(sjahr) Re-enable low_pass_filter, threshold_filter, kalman_filter, moving_mean_filter
 
 # Install Libraries
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rosparam_shortcuts
   tf2_geometry_msgs
   tf2_ros
+  pluginlib
 )
 
 add_library(low_pass_filter SHARED
@@ -58,7 +59,6 @@ target_compile_options(gravity_compensation PRIVATE -Wall -Wextra)
 # Install Libraries
 install(
   TARGETS low_pass_filter gravity_compensation
-  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -75,7 +75,7 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_libraries(gravity_compensation low_pass_filter)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
@@ -92,5 +92,8 @@ if(BUILD_TESTING)
   target_link_libraries(test_low_pass_filter low_pass_filter)
 
 endif()
+
+# Install pluginlib xml
+pluginlib_export_plugin_description_file(iirob_filters filters_plugin.xml)
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ iirob_filters
 - ROS2 Foxy
 
 ## ROS2 Port
-Only the gravity compensator and low pass filter have been ported. Both utilize dynamic parameters and require the parameters to be set before the function `configure()` is called.
-
+Only the gravity compensator has been ported.
 ## Tests
 Run the current tests:
 ```

--- a/filters_plugin.xml
+++ b/filters_plugin.xml
@@ -1,57 +1,9 @@
-<library path="lib/libiirob_filters">
-  <class name="iirob_filters/GravityCompensatorDouble" type="iirob_filters::GravityCompensator<double>" base_class_type="filters::FilterBase<double>">
-  <description>
-    This is a gravity compensator.
-  </description>
-  </class>
-  <class name="iirob_filters/LowPassFilterDouble" type="iirob_filters::LowPassFilter<double>" base_class_type="filters::FilterBase<double>">
-  <description>
-    This is a low pass filter.
-  </description>
-  </class>
-  <class name="iirob_filters/ThresholdFilterDouble" type="iirob_filters::ThresholdFilter<double>" base_class_type="filters::FilterBase<double>">
-  <description>
-    This is a threshold filter.
-  </description>
-  </class>
-  <class name="iirob_filters/LowPassFilterWrench" type="iirob_filters::LowPassFilter<geometry_msgs::WrenchStamped>" base_class_type="filters::FilterBase<geometry_msgs::WrenchStamped>">
-  <description>
-    This is a low pass filter working with geometry_msgs::WrenchStamped.
-  </description>
-  </class>
-    <class name="iirob_filters/GravityCompensatorWrench" type="iirob_filters::GravityCompensator<geometry_msgs::WrenchStamped>" base_class_type="filters::FilterBase<geometry_msgs::WrenchStamped>">
-  <description>
-    This is a gravity compensator working with geometry_msgs::WrenchStamped.
-  </description>
-  </class>
-  <class name="iirob_filters/ThresholdFilterWrench" type="iirob_filters::ThresholdFilter<geometry_msgs::WrenchStamped>" base_class_type="filters::FilterBase<geometry_msgs::WrenchStamped>">
-  <description>
-    This is a threshold filter working with geometry_msgs::WrenchStamped.
-  </description>
-  </class>
-  <class name="iirob_filters/MultiChannelLowPassFilter" type="iirob_filters::MultiChannelLowPassFilter<double>"
-	    base_class_type="filters::MultiChannelFilterBase<double>">
-  <description>
-    This is a low pass filter which works on a stream of vectors of doubles.
-  </description>
-  </class>
-  
-  <class name="iirob_filters/MultiChannelKalmanFilter" type="iirob_filters::MultiChannelKalmanFilter<double>"
-	    base_class_type="filters::MultiChannelFilterBase<double>">
+<class_libraries>
+  <library path="gravity_compensation">
+    <class name="iirob_filters/GravityCompensatorWrench" type="iirob_filters::GravityCompensator<geometry_msgs::msg::WrenchStamped>" base_class_type="filters::FilterBase<geometry_msgs::msg::WrenchStamped>">
       <description>
-	  This is a Kalman filter which works on a stream of vectors of doubles.
+        This is a gravity compensator working with geometry_msgs::WrenchStamped.
       </description>
     </class>
-  <class name="iirob_filters/MultiChannelThresholdFilter" type="iirob_filters::MultiChannelThresholdFilter<double>"
-	    base_class_type="filters::MultiChannelFilterBase<double>">
-  <description>
-    This is a threshold filter which works on a stream of vectors of doubles.
-  </description>
-  </class>
-  <class name="iirob_filters/MovingMeanFilterWrench" type="iirob_filters::MovingMeanFilter<geometry_msgs::WrenchStamped>"
-	    base_class_type="filters::FilterBase<geometry_msgs::WrenchStamped>">
-  <description>
-    This is a moving mean which works with geometry_msgs::WrenchStamped
-  </description>
-  </class>
-</library>
+  </library>
+</class_libraries>

--- a/include/iirob_filters/gravity_compensation.h
+++ b/include/iirob_filters/gravity_compensation.h
@@ -50,7 +50,6 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2/LinearMath/Transform.h>
 #include <filters/filter_base.hpp>
-//#include <rosparam_shortcuts/rosparam_shortcuts.h>
 
 namespace iirob_filters
 {
@@ -63,9 +62,6 @@ public:
 
   /** \brief Destructor */
   ~GravityCompensator();
-
-  /** @brief Init node  */
-  //void setNode(const rclcpp::Node::SharedPtr& node);
 
   /** @brief Configure filter parameters  */
   virtual bool configure() override;
@@ -80,9 +76,6 @@ public:
   bool updateParameters();
 
 private:
-  /** \brief Dynamic parameter callback activated when parameters change */
-//  void parameterCallback();
-
   rclcpp::Node::SharedPtr node_;
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
@@ -100,10 +93,6 @@ private:
   std::unique_ptr<tf2_ros::TransformListener> p_tf_Listener_;
   geometry_msgs::msg::TransformStamped transform_, transform_back_, transform_cog_;
 
-  // dynamic parameters TODO(sjahr) reenable
-//  std::unique_ptr<rosparam_shortcuts::NodeParameters> params_;
-//  bool params_updated_;
-//  bool initialized_;
   bool configured_;
 
   uint num_transform_errors_;
@@ -112,8 +101,6 @@ private:
 template <typename T>
 GravityCompensator<T>::GravityCompensator()
   : logger_(rclcpp::get_logger("GravityCompensator"))
-//  , params_updated_(false)
-//  , initialized_(false)
   , configured_(false)
   , num_transform_errors_(0)
 {
@@ -124,39 +111,12 @@ GravityCompensator<T>::~GravityCompensator()
 {
 }
 
-//template <typename T>
-//void GravityCompensator<T>::setNode(const rclcpp::Node::SharedPtr& node)
-//{
-//  node_ = node;
-//  initialized_ = true;
-//}
-
 template <typename T>
 bool GravityCompensator<T>::configure()
 {
-  //if (!initialized_)
-  //{
-  //  RCLCPP_INFO(logger_, "Node is not initialized... call setNode()");
-  //  return false;
-  //}
-
-  //p_tf_Buffer_.reset(new tf2_ros::Buffer(node_->get_clock()));
-  //clock_ = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
-
   clock_ = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   p_tf_Buffer_.reset(new tf2_ros::Buffer(clock_));
   p_tf_Listener_.reset(new tf2_ros::TransformListener(*p_tf_Buffer_.get(), true));
-  //params_.reset(new rosparam_shortcuts::NodeParameters(node_, logger_));
-
-  //params_->declareAndGet("world_frame", rclcpp::ParameterValue(), rosparam_shortcuts::always_accept);
-  //params_->declareAndGet("sensor_frame", rclcpp::ParameterValue(), rosparam_shortcuts::always_accept);
-  //params_->declareAndGet("CoG_x", rclcpp::ParameterValue(), rosparam_shortcuts::always_accept);
-  //params_->declareAndGet("CoG_y", rclcpp::ParameterValue(), rosparam_shortcuts::always_accept);
-  //params_->declareAndGet("CoG_z", rclcpp::ParameterValue(), rosparam_shortcuts::always_accept);
-  //params_->declareAndGet("force", rclcpp::ParameterValue(), rosparam_shortcuts::always_accept);
-
-  //params_->registerRosCallbackReconfigure();
-  //params_->registerUpdateCallback([this]() { parameterCallback(); });
 
   if(!updateParameters()){
     return false;
@@ -180,11 +140,6 @@ bool GravityCompensator<T>::update(const T& data_in, T& data_out)
     RCLCPP_ERROR(logger_, "Filter is not configured");
     return false;
   }
-
-  //if (params_updated_)
-  //{
-  //  updateParameters();
-  //}
 
   try
   {
@@ -221,7 +176,6 @@ bool GravityCompensator<T>::update(const T& data_in, T& data_out)
   temp_torque_transformed.vector.y -= (force_z_ * cog_transformed.vector.x);
 
   // Copy Message and Compensate values for Gravity Force and Resulting Torque
-  // geometry_msgs::WrenchStamped compensated_wrench;
   data_out = data_in;
 
   tf2::doTransform(temp_force_transformed, temp_vector_out, transform_back_);
@@ -236,8 +190,6 @@ bool GravityCompensator<T>::update(const T& data_in, T& data_out)
 template <typename T>
 bool GravityCompensator<T>::updateParameters()
 {
-  //params_updated_ = false;
-
   if (!filters::FilterBase<T>::getParam("world_frame", world_frame_)) {
     RCLCPP_ERROR(
       this->logging_interface_->get_logger(),
@@ -281,19 +233,6 @@ bool GravityCompensator<T>::updateParameters()
     return false;
   }
   return true;
-  //world_frame_ = params_->get("world_frame").as_string();
-  //sensor_frame_ = params_->get("sensor_frame").as_string();
-  //cog_.vector.x = params_->get("CoG_x").as_double();
-  //cog_.vector.y = params_->get("CoG_y").as_double();
-  //cog_.vector.z = params_->get("CoG_z").as_double();
-  //force_z_ = params_->get("force").as_double();
 }
-
-//template <typename T>
-//void GravityCompensator<T>::parameterCallback()
-//{
-//  params_updated_ = true;
-//}
-
 }  // namespace iirob_filters
 #endif

--- a/include/iirob_filters/low_pass_filter.h
+++ b/include/iirob_filters/low_pass_filter.h
@@ -59,6 +59,7 @@ public:
   /** @brief Init node  */
   void setNode(const rclcpp::Node::SharedPtr& node);
 
+  /** @brief Configure filter parameters  */
   virtual bool configure();
 
   bool configure(const std::string& ns);

--- a/package.xml
+++ b/package.xml
@@ -37,7 +37,7 @@
 
     <export>
       <build_type>ament_cmake</build_type>
-      <filters plugin="${prefix}/filters_plugin.xml"/>
+      <iirob_filters plugin="filters_plugin.xml"/>
     </export>
 
   </package>

--- a/test/test_gravity_compensation.cpp
+++ b/test/test_gravity_compensation.cpp
@@ -46,7 +46,7 @@ class GravityCompensatorFixture : public ::testing::Test
 public:
   void SetUp() override
   {
-    gravity_compensator_.setNode(node_);
+    //gravity_compensator_.setNode(node_);
 
     executor_->add_node(node_);
     executor_thread_ = std::thread([this]() { executor_->spin(); });

--- a/test/test_gravity_compensation.cpp
+++ b/test/test_gravity_compensation.cpp
@@ -46,8 +46,6 @@ class GravityCompensatorFixture : public ::testing::Test
 public:
   void SetUp() override
   {
-    //gravity_compensator_.setNode(node_);
-
     executor_->add_node(node_);
     executor_thread_ = std::thread([this]() { executor_->spin(); });
   }

--- a/test/test_low_pass_filter.cpp
+++ b/test/test_low_pass_filter.cpp
@@ -83,7 +83,7 @@ TEST_F(LowPassFilterFixture, TestLowPassFilter)
   node_->declare_parameter("damping_intensity", 1.0);
   node_->declare_parameter("divider", 1);
 
-  ASSERT_TRUE(low_pass_filter_.configure());
+  ASSERT_TRUE(low_pass_filter_.configure(""));
 
   geometry_msgs::msg::WrenchStamped in, out;
   in.header.frame_id = "world";


### PR DESCRIPTION
In order to get the package build on foxy I needed to build the single filters as separate CMake targets. Otherwise, I've experienced his error:
```
--- stderr: iirob_filters
/usr/bin/ld: CMakeFiles/iirob_filters.dir/src/low_pass_filter.cpp.o: in function `std::iterator_traits<char*>::difference_type std::__distance<char*>(char*, char*, std::random_access_iterator_tag)':
/usr/include/c++/9/bits/stl_tree.h:2405: multiple definition of `filters::impl::normalize_param_prefix(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'; CMakeFiles/iirob_filters.dir/src/gravity_compensation.cpp.o:/opt/ros/foxy/include/filters/filter_base.hpp:48: first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/iirob_filters.dir/build.make:209: libiirob_filters.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:161: CMakeFiles/iirob_filters.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
```
This PR solves the issue without the fixes suggested by [bostoncleek:pr_ros2_fixes](https://github.com/ros/filters/pull/49) and it works in combination with ros/filters ros2 branch.

Additionally, rosparam_shortcuts sadly does not work with FilterChain, so I needed to disable it temporarily and use the given NodeParameterInterface instead